### PR TITLE
Recognize index.xml and index.xhtml files at the index

### DIFF
--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -1,7 +1,7 @@
 module JekyllReadmeIndex
   class Generator < Jekyll::Generator
     README_REGEX = %r!^/readme(\.[^.]+)?$!i
-    INDEX_REGEX = %r!^/($|index\.(html?|xml)$)!i
+    INDEX_REGEX = %r!^/($|index\.(html?|xhtml|xml)$)!i
 
     attr_accessor :site
 

--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -1,7 +1,7 @@
 module JekyllReadmeIndex
   class Generator < Jekyll::Generator
     README_REGEX = %r!^/readme(\.[^.]+)?$!i
-    INDEX_REGEX = %r!^/($|index\.html?$)!i
+    INDEX_REGEX = %r!^/($|index\.(html?|xml)$)!i
 
     attr_accessor :site
 

--- a/spec/fixtures/xhtml-index/index.md
+++ b/spec/fixtures/xhtml-index/index.md
@@ -1,0 +1,5 @@
+---
+permalink: /index.xhtml
+---
+
+# XHTML Index

--- a/spec/fixtures/xml-index/index.xml
+++ b/spec/fixtures/xml-index/index.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test>
+  XML Index
+</test>

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -244,4 +244,32 @@ describe JekyllReadmeIndex::Generator do
       end
     end
   end
+
+  context "with an XHTML index" do
+    let(:fixture) { "xhtml-index" }
+
+    it "knows there's an index" do
+      expect(index?).to eql(true)
+    end
+
+    it "doesn't overwrite the index" do
+      generator.generate(site)
+      expect(site.pages.map(&:name)).to_not include("README.md")
+    end
+
+    context "building" do
+      before { site.process }
+      let(:path) { File.join(site.dest, "index.xhtml") }
+      let(:content) { File.read(path) }
+
+      it "writes the index" do
+        expect(path).to be_an_existing_file
+      end
+
+      it "renders the index as the index" do
+        expected = "<h1 id=\"xhtml-index\">XHTML Index</h1>\n"
+        expect(content).to eql(expected)
+      end
+    end
+  end
 end

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -216,4 +216,32 @@ describe JekyllReadmeIndex::Generator do
       end
     end
   end
+
+  context "with an XML index" do
+    let(:fixture) { "xml-index" }
+
+    it "knows there's an index" do
+      expect(index?).to eql(true)
+    end
+
+    it "doesn't overwrite the index" do
+      generator.generate(site)
+      expect(site.pages.map(&:name)).to_not include("README.md")
+    end
+
+    context "building" do
+      before { site.process }
+      let(:path) { File.join(site.dest, "index.xml") }
+      let(:content) { File.read(path) }
+
+      it "writes the index" do
+        expect(path).to be_an_existing_file
+      end
+
+      it "renders the index as the index" do
+        expected = "<test>\n  XML Index\n</test>\n"
+        expect(content).to match(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Expands the regex to recognize the `.xml` and `.xhtml` extensions as a valid extension.