### PR TITLE
Option to remove README.md from output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Configuration options are optional are placed in `_config.yml` under the `readme
 
 ```yml
 readme_index:
+  enabled:          true
   remove_originals: false
-  disabled:         false
 ```
 
 ### Removing originals
@@ -41,4 +41,4 @@ By default the original README markdown files will be included as static pages i
 
 ### Disabling
 
-Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `disabled` key.
+Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `enabled` key to `false`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ readme_index:
 
 ### Removing originals
 
-By default the original README markdown files will be included as static pages in the output. To remove them from the output, set the `remove_originals` key to a truthy value.
+By default the original README markdown files will be included as static pages in the output. To remove them from the output, set the `remove_originals` key to `true`.
 
 ### Disabling
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ If you have a readme file, and your site doesn't otherwise have an index file, t
   gems:
     - jekyll-readme-index
   ```
+
+## Configuration
+
+Configuration options are optional are placed in `_config.yml` under the `readme_index` key. They default to:
+
+```yml
+readme_index:
+  remove_originals: false
+  disabled:         false
+```
+
+### Removing originals
+
+By default the original README markdown files will be included as static pages in the output. To remove them from the output, set the `remove_originals` key to a truthy value.
+
+### Disabling
+
+Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `disabled` key.

--- a/jekyll-readme-index.gemspec
+++ b/jekyll-readme-index.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-$:.unshift File.expand_path('../lib', __FILE__)
-require 'jekyll-readme-index/version'
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require "jekyll-readme-index/version"
 
 Gem::Specification.new do |s|
   s.name          = "jekyll-readme-index"
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files app lib`.split("\n")
   s.platform      = Gem::Platform::RUBY
-  s.require_paths = ['lib']
+  s.require_paths = ["lib"]
   s.license       = "MIT"
 
   s.add_runtime_dependency "jekyll", "~> 3.0"

--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -8,7 +8,7 @@ module JekyllReadmeIndex
     priority :low
 
     CONFIG_KEY = "readme_index".freeze
-    DISABLED_KEY = "disabled".freeze
+    ENABLED_KEY = "enabled".freeze
     CLEANUP_KEY = "remove_originals".freeze
 
     def initialize(site)
@@ -62,7 +62,7 @@ module JekyllReadmeIndex
     end
 
     def disabled?
-      option(DISABLED_KEY)
+      option(ENABLED_KEY) == false
     end
 
     def cleanup?

--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -7,16 +7,22 @@ module JekyllReadmeIndex
     safe true
     priority :low
 
+    CONFIG_KEY = "readme_index".freeze
+    DISABLED_KEY = "disabled".freeze
+    CLEANUP_KEY = "remove_originals".freeze
+
     def initialize(site)
       @site = site
     end
 
     def generate(site)
       @site = site
+      return if disabled?
 
       readmes.each do |readme|
         next unless should_be_index?(readme)
         site.pages << readme.to_page
+        site.static_files.delete(readme) if cleanup?
       end
     end
 
@@ -49,6 +55,18 @@ module JekyllReadmeIndex
 
     def markdown_converter
       @markdown_converter ||= site.find_converter_instance(Jekyll::Converters::Markdown)
+    end
+
+    def option(key)
+      site.config[CONFIG_KEY] && site.config[CONFIG_KEY][key]
+    end
+
+    def disabled?
+      option(DISABLED_KEY)
+    end
+
+    def cleanup?
+      option(CLEANUP_KEY)
     end
   end
 end

--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -66,7 +66,7 @@ module JekyllReadmeIndex
     end
 
     def cleanup?
-      option(CLEANUP_KEY)
+      option(CLEANUP_KEY) == true
     end
   end
 end

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -1,5 +1,6 @@
 describe JekyllReadmeIndex::Generator do
-  let(:site) { fixture_site(fixture) }
+  let(:overrides) { {} }
+  let(:site) { fixture_site(fixture, overrides) }
   let(:readmes) { subject.send(:readmes) }
   let(:dir) { "/" }
   let(:index?) { subject.send(:dir_has_index?, dir) }
@@ -439,6 +440,119 @@ describe JekyllReadmeIndex::Generator do
 
         it "doesn't write the index" do
           expect(index_path).to_not be_an_existing_file
+        end
+      end
+    end
+  end
+
+  context "cleanup" do
+    let(:overrides) { { "readme_index" => { "remove_originals" => true } } }
+
+    context "with a single README" do
+      context "with a readme and no index" do
+        let(:fixture) { "readme-no-index" }
+
+        it "creates the index page" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to include("README.md")
+          expect(site.pages.map(&:url)).to include("/")
+        end
+
+        it "removes the readme file" do
+          subject.generate(site)
+          expect(site.static_files.map(&:relative_path)).to_not include("/README.md")
+        end
+      end
+
+      context "with a readme and an index" do
+        let(:fixture) { "readme-and-index" }
+
+        it "doesn't overwrite the index" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to_not include("readme.markdown")
+        end
+
+        it "doesn't remove the readme file" do
+          subject.generate(site)
+          expect(site.static_files.map(&:relative_path)).to include("/readme.markdown")
+        end
+      end
+
+      context "with a readme and a static HTML index" do
+        let(:fixture) { "readme-and-html-index" }
+
+        it "doesn't overwrite the index" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to_not include("readme.markdown")
+        end
+
+        it "doesn't remove the readme file" do
+          subject.generate(site)
+          expect(site.static_files.map(&:relative_path)).to include("/readme.markdown")
+        end
+      end
+
+      context "with a readme and a HTML index page" do
+        let(:fixture) { "readme-and-html-page-index" }
+
+        it "doesn't overwrite the index" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to_not include("readme.markdown")
+        end
+
+        it "doesn't remove the readme file" do
+          subject.generate(site)
+          expect(site.static_files.map(&:relative_path)).to include("/readme.markdown")
+        end
+      end
+
+      context "with a readme and an explicit permalink index" do
+        let(:fixture) { "readme-and-index-permalink" }
+
+        it "doesn't overwrite the index" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to_not include("readme.markdown")
+        end
+
+        it "doesn't remove the readme file" do
+          subject.generate(site)
+          expect(site.static_files.map(&:relative_path)).to include("/readme.markdown")
+        end
+      end
+    end
+
+    context "with multiple readmes" do
+      let(:fixture) { "readme-and-nested-readme" }
+
+      context "the root directory" do
+        let(:dir) { "/" }
+
+        it "creates the index page" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to include("README.md")
+          expect(site.pages.map(&:url)).to include("/")
+        end
+
+        it "does remove the root readme file" do
+          subject.generate(site)
+          readme = "/readme.markdown"
+          expect(site.static_files.map(&:relative_path)).to_not include(readme)
+        end
+      end
+
+      context "a subfolder with a readme" do
+        let(:dir) { "/with_readme/" }
+
+        it "creates the index page" do
+          subject.generate(site)
+          expect(site.pages.map(&:name)).to include("README.md")
+          expect(site.pages.map(&:url)).to include(dir)
+        end
+
+        it "does remove the subfolder readme file" do
+          subject.generate(site)
+          readme = "/with_readme/readme.markdown"
+          expect(site.static_files.map(&:relative_path)).to_not include(readme)
         end
       end
     end

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -557,4 +557,26 @@ describe JekyllReadmeIndex::Generator do
       end
     end
   end
+
+  context "when disabled" do
+    let(:fixture) { "readme-no-index" }
+    let(:overrides) { { "readme_index" => { "disabled" => true } } }
+
+    it "doesn't create the index page" do
+      subject.generate(site)
+      expect(site.pages.map(&:name)).to_not include("README.md")
+      expect(site.pages.map(&:url)).to_not include("/")
+    end
+  end
+
+  context "when explicitly enabled" do
+    let(:fixture) { "readme-no-index" }
+    let(:overrides) { { "readme_index" => { "disabled" => false } } }
+
+    it "does create the index page" do
+      subject.generate(site)
+      expect(site.pages.map(&:name)).to include("README.md")
+      expect(site.pages.map(&:url)).to include("/")
+    end
+  end
 end

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -560,7 +560,7 @@ describe JekyllReadmeIndex::Generator do
 
   context "when disabled" do
     let(:fixture) { "readme-no-index" }
-    let(:overrides) { { "readme_index" => { "disabled" => true } } }
+    let(:overrides) { { "readme_index" => { "enabled" => false } } }
 
     it "doesn't create the index page" do
       subject.generate(site)
@@ -571,7 +571,7 @@ describe JekyllReadmeIndex::Generator do
 
   context "when explicitly enabled" do
     let(:fixture) { "readme-no-index" }
-    let(:overrides) { { "readme_index" => { "disabled" => false } } }
+    let(:overrides) { { "readme_index" => { "enabled" => true } } }
 
     it "does create the index page" do
       subject.generate(site)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,10 @@ def fixture_path(fixture)
   File.expand_path "./fixtures/#{fixture}", File.dirname(__FILE__)
 end
 
-def fixture_site(fixture)
-  config = Jekyll.configuration("source" => fixture_path(fixture))
+def fixture_site(fixture, override = {})
+  default_config = { "source" => fixture_path(fixture) }
+  config = Jekyll::Utils.deep_merge_hashes(default_config, override)
+  config = Jekyll.configuration(config)
   Jekyll::Site.new(config)
 end
 


### PR DESCRIPTION
Similar to benbalter/jekyll-optional-front-matter#9, allows readme files to be removed from the output when enabled by:

```yml
readme_index:
  remove_originals: true
```

Also adds `disabled` option, to be consistent with benbalter/jekyll-optional-front-matter#9.
