### PR TITLE
Add support for overriding the README-recognizing regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ readme_index:
   enabled:          true
   remove_originals: false
   with_frontmatter: false
+  regex:            null
 ```
 
 ### Removing originals

--- a/lib/jekyll-readme-index/generator.rb
+++ b/lib/jekyll-readme-index/generator.rb
@@ -13,6 +13,7 @@ module JekyllReadmeIndex
     ENABLED_KEY = "enabled"
     CLEANUP_KEY = "remove_originals"
     FRONTMATTER_KEY = "with_frontmatter"
+    REGEX_KEY = "regex"
 
     def initialize(site)
       @site = site
@@ -67,7 +68,12 @@ module JekyllReadmeIndex
 
     # Regexp to match a file path against to detect if the given file is a README
     def readme_regex
-      @readme_regex ||= %r!/readme(#{Regexp.union(markdown_converter.extname_list)})$!i
+      regex = option(REGEX_KEY)
+      if regex
+        @readme_regex ||= Regexp.new(regex)
+      else
+        @readme_regex ||= %r!/readme(#{Regexp.union(markdown_converter.extname_list)})$!i
+      end
     end
 
     def markdown_converter

--- a/spec/fixtures/readme-and-override/.github/README.md
+++ b/spec/fixtures/readme-and-override/.github/README.md
@@ -1,0 +1,1 @@
+# Jekyll Readme Index Override

--- a/spec/fixtures/readme-and-override/README.md
+++ b/spec/fixtures/readme-and-override/README.md
@@ -1,0 +1,1 @@
+# Jekyll Readme Index

--- a/spec/jekyll-readme-index/generator_spec.rb
+++ b/spec/jekyll-readme-index/generator_spec.rb
@@ -310,6 +310,46 @@ describe JekyllReadmeIndex::Generator do
         end
       end
     end
+
+    context "with a readme and an override" do
+      let(:fixture) { "readme-and-override" }
+      let(:overrides) { { "readme_index" => { "regex" => "\/.github\/README.md" } } }
+
+      it "knows there's a readme" do
+        expect(readme).not_to be_nil
+        expect(readme.class).to eql(Jekyll::StaticFile)
+        expect(readme.relative_path).to eql("/.github/README.md")
+      end
+
+      it "knows the readme should be the index" do
+        expect(should_be_index?).to be(true)
+      end
+
+      it "builds the index page" do
+        expect(page.class).to eql(Jekyll::Page)
+        expect(page.content).to eql("# Jekyll Readme Index Override\n")
+        expect(page.url).to eql("/")
+      end
+
+      it "creates the index page" do
+        subject.generate(site)
+        expect(site.pages.map(&:name)).to include("README.md")
+        expect(site.pages.map(&:url)).to include("/")
+      end
+
+      context "when building" do
+        before { site.process }
+
+        it "writes the index" do
+          expect(index_path).to be_an_existing_file
+        end
+
+        it "renders the markdown to HTML" do
+          expected = "<h1 id=\"jekyll-readme-index\">Jekyll Readme Index Override</h1>\n"
+          expect(index_content).to eql(expected)
+        end
+      end
+    end
   end
 
   context "with multiple readmes" do


### PR DESCRIPTION
This can be used to configure the plugin to use one of the alternative READMEs GitHub supports or even any other custom file!

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes

> If you put your README file in your repository's hidden `.github`, `root`, or
> `docs` directory, GitHub will recognize and automatically surface your README
> to repository visitors.

> If a repository contains more than one README file, then the file shown is
> chosen from locations in the following order: the `.github` directory, then
> the repository's `root` directory, and finally the `docs` directory.

Closes #38 