### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 0.4.0
+
+### Features
+
+- Support READMEs in `.github/` and `docs/` as the site index, following
+  GitHub's precedence (`.github` > root > `docs`) (#48)
+
+### Bug fixes
+
+- Fix a bug where a README with front matter in a nested directory was moved
+  to its parent directory (#43)
+
+### Dependencies
+
+- Constrain gemspec dependencies to their latest compatible versions (#45)
+
+### Infrastructure
+
+- Modernize CI — test Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x (#52)
+- Migrate CI from Travis to GitHub Actions; add CodeQL analysis
+- Enable Dependabot for GitHub Actions; bump `actions/checkout` and
+  `github/codeql-action` (#49, #50, #51)
+- Stop tracking the vendored `vendor/` directory

--- a/lib/jekyll-readme-index/version.rb
+++ b/lib/jekyll-readme-index/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllReadmeIndex
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Prepares **v0.4.0** (minor — new feature). Adds a `CHANGELOG.md` (none existed). Publish is a manual `gem push` after merge.

**Bump:** 0.3.0 → 0.4.0 (minor: `.github/` + `docs/` README support)

### Changelog
**Features**
- Support READMEs in `.github/` and `docs/` as the site index, following GitHub's precedence (`.github` > root > `docs`) (#48)

**Bug fixes**
- Fix a README with front matter in a nested directory being moved to its parent (#43)

**Dependencies**
- Constrain gemspec dependencies to their latest compatible versions (#45)

**Infrastructure**
- Modernize CI (Ruby 3.3 & 4.0 × Jekyll 3.x & 4.x) (#52); migrate Travis → GitHub Actions; add CodeQL
- Enable Dependabot for GitHub Actions; bump `actions/checkout` and `github/codeql-action` (#49, #50, #51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)