### PR TITLE
Declare required_ruby_version >= 3.0

### DIFF
--- a/jekyll-readme-index.gemspec
+++ b/jekyll-readme-index.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "benchmark"
   s.add_development_dependency "ostruct"
   s.add_development_dependency "tsort"
+
+  s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Sets `s.required_ruby_version = ">= 3.0"` to match the supported/tested Ruby matrix (3.3, 4.0) and clear the `gem build` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)